### PR TITLE
5_auditing: add example of decrypting an encrypted query and replay

### DIFF
--- a/5_auditing/encrypted_query_replay.rb
+++ b/5_auditing/encrypted_query_replay.rb
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require "base64"
 require "json"
+require "openssl"
+require "openssl/oaep"
+
 require "strongdm"
 
 # Load the SDM API keys from the environment.
@@ -26,6 +30,16 @@ if api_access_key.nil? || api_secret_key.nil?
   return
 end
 
+# Load the private key for query and replay decryption.
+# This environment variable should contain the path to the private encryption
+# key configured for StrongDM remote log encryption.
+private_key_file = ENV["SDM_LOG_PRIVATE_KEY_FILE"]
+if private_key_file.nil?
+  puts "SDM_LOG_PRIVATE_KEY_FILE must be provided for this example"
+  return
+end
+private_key = OpenSSL::PKey::RSA.new(File.read(private_key_file))
+
 # Create the SDM client
 client = SDM::Client.new(api_access_key, api_secret_key)
 
@@ -38,17 +52,55 @@ resource = resources.to_a[0]
 puts "Queries made against #{resource_name}"
 queries = client.queries.list("resource_id:?", resource.id)
 
+# This method demonstrates how to decrypt encrypted query/replay data
+def decrypt_query_data(private_key, encrypted_query_key, encrypted_data)
+  # Use the organization's private key to decrypt the symmetric key
+  sym_key = private_key.private_decrypt_oaep(
+    Base64.decode64(encrypted_query_key),
+    "",
+    OpenSSL::Digest::SHA256,
+    OpenSSL::Digest::SHA256,
+  )
+  # Use the symmetric key to decrypt the data
+  cipher = OpenSSL::Cipher::AES256.new(:CBC)
+  cipher.decrypt
+  cipher.padding = 0
+  cipher.key = sym_key
+  cipher.iv = encrypted_data[0..cipher.block_size - 1]
+  ciphertext = encrypted_data[cipher.block_size..]
+  plaintext = cipher.update(ciphertext) + cipher.final
+  return plaintext.gsub(/\x00+$/, "")
+end
+
 for query in queries
   response = client.snapshot_at(query.timestamp).accounts.get(query.account_id)
   account = response.account
 
   if query.encrypted
-    puts "Skipping encrypted query made #{account.email} at #{query.timestamp}"
-    puts "See encrypted_query_replay.rb for an example of query decryption."
-  elsif query.replayable
+    puts "Decrypting encrypted query"
+    query.query_body = decrypt_query_data(
+      private_key,
+      query.query_key,
+      Base64.decode64(query.query_body),
+    )
+    query.replayable = JSON.parse(query.query_body)["type"] == "shell"
+  end
+
+  if query.replayable
     puts "Replaying query made by #{account.email} at #{query.timestamp}"
     replay_parts = client.replays.list("id:?", query.id)
     for part in replay_parts
+      if query.encrypted
+        events = JSON.parse(
+          decrypt_query_data(private_key, query.query_key, part.data)
+        )
+        part.events = events.map do |e|
+          SDM::ReplayChunkEvent.new(
+            data: Base64.decode64(e["data"]),
+            duration: e["duration"] / 1000.0,
+          )
+        end
+      end
       for event in part.events
         print(event.data)
         sleep(event.duration)


### PR DESCRIPTION
This example demonstrates how to decrypt the content of a query and its replay (when replayable) when an organization has enabled remote log encryption using their own key.

This is separate from query_replay.rb to keep the non-encrypted example code as simple as possible.