### PR TITLE
Add examples for the new Policies APIs in 11.3.0

### DIFF
--- a/8_policies/README.md
+++ b/8_policies/README.md
@@ -1,0 +1,3 @@
+# Managing Policies
+
+A collection of examples regarding managing of policies.

--- a/8_policies/crud_policy.rb
+++ b/8_policies/crud_policy.rb
@@ -1,0 +1,78 @@
+# Copyright 2024 StrongDM Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'strongdm'
+
+# Load the SDM API keys from the environment.
+# If these values are not set in your environment,
+# please follow the documentation here:
+# https://www.strongdm.com/docs/api/api-keys/
+api_access_key = ENV['SDM_API_ACCESS_KEY']
+api_secret_key = ENV['SDM_API_SECRET_KEY']
+if api_access_key.nil? || api_secret_key.nil?
+  puts 'SDM_API_ACCESS_KEY and SDM_API_SECRET_KEY must be provided'
+  return
+end
+
+# Create the SDM client
+client = SDM::Client.new(api_access_key, api_secret_key)
+
+# Create a 30 second deadline
+deadline = Time.now.utc + 30
+
+policy = SDM::Policy.new(
+  name: 'forbid-everything',
+  description: 'Forbid everything',
+  policy: 'forbid ( principal, action, resource );'
+)
+
+create_resp = client.policies.create(policy, deadline: deadline)
+puts 'Successfully created Policy'
+puts "\tID: #{create_resp.policy.id}"
+puts "\tName: #{create_resp.policy.name}"
+
+# Note: The `policy` field in `create_resp` can also be used to make an
+# update. However, we'll load it from the API to demonstrate `get`.
+get_resp = client.policies.get(create_resp.policy.id, deadline: deadline)
+puts 'Successfully retrieved policy.'
+puts "\tID: #{get_resp.policy.id}"
+puts "\tName: #{get_resp.policy.name}"
+
+update_policy = get_resp.policy
+update_policy.name = 'forbid-one-thing'
+update_policy.description = 'forbid connecting to the bad resource'
+update_policy.policy = <<-EOP
+forbid (
+     principal,
+     action == StrongDM::Action::"connect",
+     resource == StrongDM::Resource::"rs-123d456789"
+);
+EOP
+
+# Update the policy with new values
+update_resp = client.policies.update(update_policy, deadline: deadline)
+puts "Successfully retrieved policy."
+puts "\tID: #{update_resp.policy.id}"
+puts "\tName: #{update_resp.policy.name}"
+puts "\tDescription: #{update_resp.policy.description}"
+puts "\tPolicy: #{update_resp.policy.policy}"
+
+# Delete the policy
+client.policies.delete(create_resp.policy.id, deadline: deadline)
+
+# Try to retrieve a deleted policy
+begin
+  client.policies.get(create_resp.policy.id, deadline: deadline)
+rescue SDM::NotFoundError
+end

--- a/8_policies/find_policy.rb
+++ b/8_policies/find_policy.rb
@@ -1,0 +1,87 @@
+# Copyright 2024 StrongDM Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'strongdm'
+
+example_policies = [
+    SDM::Policy.new(
+        name: 'default-permit-policy',
+        description: 'a default permit policy',
+        policy: 'permit (principal, action, resource);'
+    ),
+    SDM::Policy.new(
+        name: 'permit-sql-select-policy',
+        description: 'a permit sql select policy',
+        policy: 'permit (principal, action == SQL::Action::"select", resource == Postgres::Database::"*");'
+    ),
+    SDM::Policy.new(
+        name: 'default-forbid-policy',
+        description: 'a default forbid policy',
+        policy: 'forbid (principal, action, resource);'
+    ),
+    SDM::Policy.new(
+        name: 'forbid-connect-policy',
+        description: 'a forbid connect policy',
+        policy: 'forbid (principal, action == StrongDM::Action::"connect", resource);'
+    ),
+    SDM::Policy.new(
+        name: 'forbid-sql-delete-policy',
+        description: 'a forbid delete policy on all resources',
+        policy: 'forbid (principal, action == SQL::Action::"delete", resource == Postgres::Database::"*");'
+      )
+]
+
+
+# Load the SDM API keys from the environment.
+# If these values are not set in your environment,
+# please follow the documentation here:
+# https://www.strongdm.com/docs/api/api-keys/
+api_access_key = ENV['SDM_API_ACCESS_KEY']
+api_secret_key = ENV['SDM_API_SECRET_KEY']
+if api_access_key.nil? || api_secret_key.nil?
+  puts 'SDM_API_ACCESS_KEY and SDM_API_SECRET_KEY must be provided'
+  return
+end
+
+# Create the SDM client
+client = SDM::Client.new(api_access_key, api_secret_key)
+
+
+# Create a 30 second deadline
+deadline = Time.now.utc + 30
+
+policies_to_cleanup = example_policies.map do |p|
+  create_resp = client.policies.create(p, deadline: deadline)
+  puts "Successfully created Policy"
+  puts "\tID: #{create_resp.policy.id}"
+  puts "\tName: #{create_resp.policy.name}"
+  create_resp.policy
+end
+
+# Find policies related to `sql` by Name
+puts "Finding all Policies with a name containing 'sql'"
+for p in client.policies.list('name:*sql*') do
+    puts "\tID: #{p.id}\tName: #{p.name}"
+end
+
+# Find policies that forbid based on Policy
+puts 'Finding all Policies that forbid'
+for p in client.policies.list('policy:forbid*') do
+    puts "\tID: #{p.id}\tName: #{p.name}"
+end
+
+# Cleanup the policies we created
+policies_to_cleanup.each do |p|
+  client.policies.delete(p.id)
+end


### PR DESCRIPTION
This adds two examples that make use of the Policies API in SDKs 11.3.0 and later. These are ported from the Policies examples in [strongdm-sdk-go-examples](https://github.com/strongdm/strongdm-sdk-go-examples/tree/master/8_policies)

The first, crud_policy, creates, updates, and then deletes a Policy. It then verifies that the Policy was deleted by making a Get request and ensuring that it was not found.

In the second example, find_policy, we creates examples Policies and then perform 2 filtered searches on them.

These were tested manually.