### PR TITLE
PO-499: Add example of setting a user password

### DIFF
--- a/2_managing_accounts/set_password.rb
+++ b/2_managing_accounts/set_password.rb
@@ -1,0 +1,62 @@
+# Copyright 2024 StrongDM Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'strongdm'
+
+# Load the SDM API keys from the environment.
+# If these values are not set in your environment,
+# please follow the documentation here:
+# https://www.strongdm.com/docs/api/api-keys/
+api_access_key = ENV['SDM_API_ACCESS_KEY']
+api_secret_key = ENV['SDM_API_SECRET_KEY']
+if api_access_key.nil? || api_secret_key.nil?
+  puts 'SDM_API_ACCESS_KEY and SDM_API_SECRET_KEY must be provided'
+  return
+end
+
+# Create the SDM client
+client = SDM::Client.new(api_access_key, api_secret_key)
+
+# Create an account
+# Setting a password when creating an account is not supported
+user = SDM::User.new(
+  email: 'ruby-set-password@example.com',
+  first_name: 'example',
+  last_name: 'example',
+  permission_level: SDM::PermissionLevel::USER
+)
+
+create_response = client.accounts.create(user)
+puts 'Successfully created user.'
+puts "\tID: #{create_response.account.id}"
+puts "\tEmail: #{create_response.account.email}"
+
+# Password is a write-only field
+# The current password is never returned in any responses
+raise 'Password not empty' unless create_response.account.password == ''
+
+# Get the account
+get_response = client.accounts.get(create_response.account.id)
+account = get_response.account
+raise 'Password not empty' unless account.password == ''
+
+# Set new password according to organization password complexity requirements
+account.password = 'correct horse battery staple'
+
+# Update the account with the new password
+update_response = client.accounts.update(account)
+raise 'Password not empty' unless update_response.account.password == ''
+puts 'Successfully updated password.'
+puts "\tID: #{update_response.account.id}"
+puts "\tNew password: #{account.password}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-ruby '3.3.0'
+ruby '>=3.1.0'
 
-gem 'strongdm'
-gem 'openssl-oaep'
+gem 'strongdm', '>=11.10.0'
+gem 'openssl-oaep', '0.1.0'
+gem 'grpc', '1.46.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.25.3)
-    google-protobuf (3.25.3-aarch64-linux)
-    google-protobuf (3.25.3-arm64-darwin)
-    google-protobuf (3.25.3-x86-linux)
-    google-protobuf (3.25.3-x86_64-darwin)
-    google-protobuf (3.25.3-x86_64-linux)
-    googleapis-common-protos-types (1.14.0)
-      google-protobuf (~> 3.18)
-    grpc (1.62.0)
-      google-protobuf (~> 3.25)
+    google-protobuf (3.25.4)
+    google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-arm64-darwin)
+    google-protobuf (3.25.4-x86-linux)
+    google-protobuf (3.25.4-x86_64-darwin)
+    google-protobuf (3.25.4-x86_64-linux)
+    googleapis-common-protos-types (1.16.0)
+      google-protobuf (>= 3.18, < 5.a)
+    grpc (1.46.2)
+      google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.0-aarch64-linux)
-      google-protobuf (~> 3.25)
+    grpc (1.46.2-x86-linux)
+      google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.0-arm64-darwin)
-      google-protobuf (~> 3.25)
+    grpc (1.46.2-x86_64-darwin)
+      google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.0-x86-linux)
-      google-protobuf (~> 3.25)
+    grpc (1.46.2-x86_64-linux)
+      google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.0-x86_64-darwin)
-      google-protobuf (~> 3.25)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.0-x86_64-linux)
-      google-protobuf (~> 3.25)
-      googleapis-common-protos-types (~> 1.0)
-    grpc-tools (1.62.0)
+    grpc-tools (1.66.0)
     openssl (3.2.0)
     openssl-oaep (0.1.0)
-    strongdm (8.0.0)
+    strongdm (11.10.0)
       grpc (~> 1.36)
       grpc-tools (~> 1.36)
       openssl (~> 3.1)
@@ -44,11 +38,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  openssl-oaep
-  strongdm
+  grpc (= 1.46.2)
+  openssl-oaep (= 0.1.0)
+  strongdm (>= 11.10.0)
 
 RUBY VERSION
-   ruby 3.3.0p0
+   ruby 3.1.2p20
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
This PR adds an example setting a user password using the SDK.

While this is similar to updating other fields for a user account, the special nuances around password updates (password being a write-only and update-only field, and being under a separate permission) warrant a separate example illustrating those differences.

This PR also bumps the minimum SDK version in the Gemfile to the minimum version required to run all examples, which is now 11.10.0, along with forcing some specific dependency version requirements so that the examples can be run after a `bundle install` without errors.

Addresses PO-499