### PR TITLE
ENG-2653: Examples for Manager Approvals For Approval Workflows

### DIFF
--- a/7_managing_approval_workflows/list_approval_workflow.rb
+++ b/7_managing_approval_workflows/list_approval_workflow.rb
@@ -65,7 +65,9 @@ approval_workflow = SDM::ApprovalWorkflow.new(
     SDM::ApprovalFlowStep.new(
         quantifier: "all",
         approvers: [
-            SDM::ApprovalFlowApprover.new(account_id: account_id)
+            SDM::ApprovalFlowApprover.new(account_id: account_id),
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_REQUESTER),
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_MANAGER_OF_REQUESTER)
         ]
     )
   ]

--- a/7_managing_approval_workflows/list_approval_workflow.rb
+++ b/7_managing_approval_workflows/list_approval_workflow.rb
@@ -66,8 +66,8 @@ approval_workflow = SDM::ApprovalWorkflow.new(
         quantifier: "all",
         approvers: [
             SDM::ApprovalFlowApprover.new(account_id: account_id),
-            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_REQUESTER),
-            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_MANAGER_OF_REQUESTER)
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference::MANAGER_OF_REQUESTER),
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference::MANAGER_OF_MANAGER_OF_REQUESTER)
         ]
     )
   ]

--- a/7_managing_approval_workflows/manual_approval_workflow.rb
+++ b/7_managing_approval_workflows/manual_approval_workflow.rb
@@ -73,7 +73,8 @@ approval_workflow = SDM::ApprovalWorkflow.new(
         quantifier: "all",
         approvers: [
             SDM::ApprovalFlowApprover.new(account_id: account_id),
-            SDM::ApprovalFlowApprover.new(account_id: account2_id)
+            SDM::ApprovalFlowApprover.new(account_id: account2_id),
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_REQUESTER)
         ]
     )
   ]
@@ -113,7 +114,8 @@ updated_flow_configuration = SDM::ApprovalWorkflow.new(
         quantifier: "any",
         skip_after: 240, # in minutes
         approvers: [
-            SDM::ApprovalFlowApprover.new(account_id: account2_id)
+            SDM::ApprovalFlowApprover.new(account_id: account2_id),
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_MANAGER_OF_REQUESTER)
         ]
     )
   ]

--- a/7_managing_approval_workflows/manual_approval_workflow.rb
+++ b/7_managing_approval_workflows/manual_approval_workflow.rb
@@ -74,7 +74,7 @@ approval_workflow = SDM::ApprovalWorkflow.new(
         approvers: [
             SDM::ApprovalFlowApprover.new(account_id: account_id),
             SDM::ApprovalFlowApprover.new(account_id: account2_id),
-            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_REQUESTER)
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference::MANAGER_OF_REQUESTER)
         ]
     )
   ]
@@ -115,7 +115,7 @@ updated_flow_configuration = SDM::ApprovalWorkflow.new(
         skip_after: 240, # in minutes
         approvers: [
             SDM::ApprovalFlowApprover.new(account_id: account2_id),
-            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference.MANAGER_OF_MANAGER_OF_REQUESTER)
+            SDM::ApprovalFlowApprover.new(reference: SDM::ApproverReference::MANAGER_OF_MANAGER_OF_REQUESTER)
         ]
     )
   ]


### PR DESCRIPTION
Addresses ENG-2653

We introduce the ability to specify the "manager-of-requester" or "manager-of-manager-of-requester" as an approver for approval workflows and update the examples to reflect that.

## QA

Validated examples run on local system.  